### PR TITLE
fix: remove LaTeX remnants in HTML/CSS section

### DIFF
--- a/98_htmlcss/index.md
+++ b/98_htmlcss/index.md
@@ -11,9 +11,9 @@
     -   Opening tag `<tagname>` shows where the element begins
     -   Closing tag `</tagname>` shows where it ends
 -   Elements must form a tree, i.e., must be strictly nested
-    -   `<X>{\ldots}<Y>{\ldots}</Y></X>` is legal
-    -   `<X>{\ldots}<Y>{\ldots}</X></Y>` is not
--   And every document should have a single [root element](g:root-element)\index{element!root} that encloses everything else
+    -   `<X>...<Y>...</Y></X>` is legal
+    -   `<X>...<Y>...</X></Y>` is not
+-   And every document should have a single [root element](g:root-element) that encloses everything else
 -   Since `<` and `>` are used to show where tags start and end,
     must use [escape sequences](g:escape-sequence) to represent them
     -   Written `&name;`

--- a/docs/98_htmlcss/index.html
+++ b/docs/98_htmlcss/index.html
@@ -25,11 +25,11 @@
 </ul>
 </li>
 <li>Elements must form a tree, i.e., must be strictly nested<ul>
-<li><code>&lt;X&gt;{\ldots}&lt;Y&gt;{\ldots}&lt;/Y&gt;&lt;/X&gt;</code> is legal</li>
-<li><code>&lt;X&gt;{\ldots}&lt;Y&gt;{\ldots}&lt;/X&gt;&lt;/Y&gt;</code> is not</li>
+<li><code>&lt;X&gt;...&lt;Y&gt;...&lt;/Y&gt;&lt;/X&gt;</code> is legal</li>
+<li><code>&lt;X&gt;...&lt;Y&gt;...&lt;/X&gt;&lt;/Y&gt;</code> is not</li>
 </ul>
 </li>
-<li>And every document should have a single <a href="../glossary.html#root-element">root element</a>\index{element!root} that encloses everything else</li>
+<li>And every document should have a single <a href="../glossary.html#root-element">root element</a> that encloses everything else</li>
 <li>Since <code>&lt;</code> and <code>&gt;</code> are used to show where tags start and end,
     must use <a href="../glossary.html#escape-sequence">escape sequences</a> to represent them<ul>
 <li>Written <code>&amp;name;</code></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,6 +48,7 @@ Suggestions and help are greatly appreciated.</p>
 </ul>
 <h2>Syllabus</h2>
 <ol class="chapters">
+<ol>
 <li><a href="./01_intro/index.html">Introduction</a>: what we will learn, how to set up, and the data we will use</li>
 <li><a href="./02_http/index.html">HTTP</a>: how browsers and server talk to each other</li>
 <li><a href="./03_server/index.html">A Server</a>: building a server with <a href="https://flask.palletsprojects.com/">Flask</a></li>
@@ -71,13 +72,16 @@ Suggestions and help are greatly appreciated.</p>
 <li><a href="./21_sessions/index.html">Session</a>: persistent sessions and <a href="https://en.wikipedia.org/wiki/JSON_Web_Token">JWT</a></li>
 <li><a href="./22_workflow/index.html">Designing a Workflow</a>: thinking before coding</li>
 </ol>
+</ol>
 <h2>Appendices</h2>
 <ol class="appendices">
+<ol>
 <li><a href="./98_htmlcss/index.html">HTML and CSS</a></li>
 <li><a href="./99_cert/index.html">Certificates</a></li>
 <li><a href="./bibliography.html">Bibliography</a></li>
 <li><a href="./glossary.html">Glossary</a></li>
 <li><a href="./contributing.html">Contributing</a></li>
+</ol>
 </ol>
 <h2>Technologies</h2>
 <table>


### PR DESCRIPTION
I would apply the fix myself, but I lack writing access rights