### PR TITLE
feat: add an example of using JWT authentication

### DIFF
--- a/21_sessions/Makefile
+++ b/21_sessions/Makefile
@@ -12,3 +12,7 @@ sessions:
 	make migrate_sessions
 	SECRET=$$(cat secret.txt) DATA=temp.db flask --app server_sessions.py run
 
+## jwt: run secure server with JWT authentication
+jwt:
+	make migrate_sessions
+	SECRET=$$(cat secret.txt) JWT_SECRET=$$(openssl rand -hex 32) DATA=temp.db flask --app server_secure_jwt.py run

--- a/21_sessions/index.md
+++ b/21_sessions/index.md
@@ -14,6 +14,17 @@
     - Encode and sign user claims as JSON
     - Client stores the resulting token
     - [jwt.io][jwt-io] allows you to decode, verify and generate JWT.
+- JWT-based authentication implemented in [`server_secure_jwt.py`](./server_secure_jwt.py)
+    - Uses `pyjwt` library for JSON Web Token handling
+    - Generates a token upon successful login, storing staff ID and expiration time
+    - Token _should_ be set as an HTTP-only cookie for security (when a cookie is marked as HTTP-only, JavaScript can no longer access the cookie using `document.cookie`, preventing cross-site scripting (XSS) attacks)
+    - Protected routes (like `/exp/<staff_id>`) verify the JWT before granting access
+    - Provides stateless authentication, improving scalability
+        - JWTs are stateless, meaning the server doesn't need to store session information.
+        - This reduces server memory usage and makes scaling easier.
+    - Handles token expiration and invalid tokens
+    - Uses environment variables for JWT secret
+    - Once authenticated, you will see the cookie value. Check it in [jwt-io].
     
 [jwt]: https://en.wikipedia.org/wiki/JSON_Web_Token
 [jwt-io]: https://jwt.io

--- a/21_sessions/server_secure_jwt.py
+++ b/21_sessions/server_secure_jwt.py
@@ -1,0 +1,98 @@
+"""Serve data from data model layer with JWT authentication."""
+
+from flask import Flask, abort, make_response, redirect, request, url_for, jsonify
+from flask_cors import CORS
+from pathlib import Path
+import jwt
+from datetime import datetime, timedelta, timezone
+import os
+
+import models
+import views
+from util import AppException, HTTP_400_BAD_REQUEST, encrypt_password, get_secret
+
+COOKIE_NAME = "wp4ds"
+HEARTBEAT = {"message": "alive"}
+JWT_SECRET = os.environ.get('JWT_SECRET')
+JWT_ALGORITHM = 'HS256'
+JWT_EXPIRATION_DELTA = timedelta(hours=1)
+
+def create_app():
+    """Build application and configure routes."""
+    app = Flask("server", static_folder=Path("../static").absolute(), static_url_path="/static")
+    CORS(app)
+
+    secret = get_secret()
+
+    def create_token(staff_id):
+        payload = {
+            'exp': datetime.now(timezone.utc) + JWT_EXPIRATION_DELTA,
+            'iat': datetime.now(timezone.utc),
+            'staffId': staff_id
+        }
+        return jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
+
+    def decode_token(token):
+        try:
+            payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+            return payload['staffId']
+        except jwt.ExpiredSignatureError:
+            return None  # Token has expired
+        except jwt.InvalidTokenError:
+            return None  # Invalid token
+
+    @app.get("/")
+    def root():
+        try:
+            return views.all_staff(models.all_staff())
+        except AppException as exc:
+            abort(HTTP_400_BAD_REQUEST, f"Error serving all staff: {exc}")
+
+    @app.post("/login")
+    def login_handler():
+        """Accept password and go back home."""
+        username = request.form["username"]
+        password = request.form["password"]
+        response = make_response(redirect(url_for("root")))
+
+        if (not username) or (not password):
+            response.set_cookie(COOKIE_NAME, "", expires=0)
+            return response
+
+        password = encrypt_password(secret, password)
+        staff_id = models.authenticate(username, password)
+        if staff_id is None:
+            response.set_cookie(COOKIE_NAME, "", expires=0)
+            return response
+
+        token = create_token(staff_id)
+        response.set_cookie(COOKIE_NAME, token, samesite='Lax')
+        return response
+
+    @app.get("/exp/<staff_id>")
+    def exp(staff_id):
+        staff_id = int(staff_id)
+        token = request.cookies.get(COOKIE_NAME)
+        if not token:
+            return jsonify({"error": "Not authenticated"}), 401
+
+        decoded_staff_id = decode_token(token)
+        if decoded_staff_id is None:
+            return jsonify({"error": "Invalid or expired token"}), 401
+
+        try:
+            if int(decoded_staff_id) == staff_id:
+                return views.experiments(models.experiments(staff_id), staff_id)
+            else:
+                return jsonify({"error": "Not authorized"}), 403
+        except AppException as exc:
+            abort(HTTP_400_BAD_REQUEST, f"Error serving experiments for {staff_id}: {exc}")
+
+    @app.get("/heartbeat")
+    def heartbeat():
+        try:
+            return views.heartbeat(HEARTBEAT)
+        except AppException as exc:
+            abort(HTTP_400_BAD_REQUEST, f"Error serving heartbeat: {exc}")
+
+    return app

--- a/21_sessions/templates/staff.html
+++ b/21_sessions/templates/staff.html
@@ -7,6 +7,7 @@
     <script src="/static/htmx.js"></script>
     <script src="/static/alpine.js" defer></script>
     <script src="/static/cookies.js"></script>
+
   </head>
   <body>
     <h1>Staff and Experiments</h1>
@@ -49,6 +50,20 @@
         </fieldset>
       </form>
     </div>
-    <div id="experiments"></div>
+    <div id="experiments"
+         hx-target="this"
+         hx-swap="innerHTML"
+    >
+    </div>
+
+    <script>
+      document.body.addEventListener('htmx:responseError', function(evt) {
+        if (evt.detail.xhr.status === 403) {
+          evt.detail.target.innerHTML = '<p class="error-message">Not authorized</p>';
+        } else if (evt.detail.xhr.status === 401) {
+          evt.detail.target.innerHTML = '<p class="error-message">Not authenticated</p>';
+        }
+      });
+    </script>
   </body>
 </html>

--- a/docs/21_sessions/index.html
+++ b/docs/21_sessions/index.html
@@ -34,6 +34,21 @@
 <li><a href="https://jwt.io">jwt.io</a> allows you to decode, verify and generate JWT.</li>
 </ul>
 </li>
+<li>JWT-based authentication implemented in <a href="./server_secure_jwt.py"><code>server_secure_jwt.py</code></a><ul>
+<li>Uses <code>pyjwt</code> library for JSON Web Token handling</li>
+<li>Generates a token upon successful login, storing staff ID and expiration time</li>
+<li>Token <em>should</em> be set as an HTTP-only cookie for security (when a cookie is marked as HTTP-only, JavaScript can no longer access the cookie using <code>document.cookie</code>, preventing cross-site scripting (XSS) attacks)</li>
+<li>Protected routes (like <code>/exp/&lt;staff_id&gt;</code>) verify the JWT before granting access</li>
+<li>Provides stateless authentication, improving scalability<ul>
+<li>JWTs are stateless, meaning the server doesn't need to store session information.</li>
+<li>This reduces server memory usage and makes scaling easier.</li>
+</ul>
+</li>
+<li>Handles token expiration and invalid tokens</li>
+<li>Uses environment variables for JWT secret</li>
+<li>Once authenticated, you will see the cookie value. Check it in <a href="https://jwt.io">jwt-io</a>.</li>
+</ul>
+</li>
 </ul>
 </main>
 <footer>

--- a/docs/21_sessions/server_secure_jwt.py
+++ b/docs/21_sessions/server_secure_jwt.py
@@ -1,0 +1,98 @@
+"""Serve data from data model layer with JWT authentication."""
+
+from flask import Flask, abort, make_response, redirect, request, url_for, jsonify
+from flask_cors import CORS
+from pathlib import Path
+import jwt
+from datetime import datetime, timedelta, timezone
+import os
+
+import models
+import views
+from util import AppException, HTTP_400_BAD_REQUEST, encrypt_password, get_secret
+
+COOKIE_NAME = "wp4ds"
+HEARTBEAT = {"message": "alive"}
+JWT_SECRET = os.environ.get('JWT_SECRET')
+JWT_ALGORITHM = 'HS256'
+JWT_EXPIRATION_DELTA = timedelta(hours=1)
+
+def create_app():
+    """Build application and configure routes."""
+    app = Flask("server", static_folder=Path("../static").absolute(), static_url_path="/static")
+    CORS(app)
+
+    secret = get_secret()
+
+    def create_token(staff_id):
+        payload = {
+            'exp': datetime.now(timezone.utc) + JWT_EXPIRATION_DELTA,
+            'iat': datetime.now(timezone.utc),
+            'staffId': staff_id
+        }
+        return jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
+
+    def decode_token(token):
+        try:
+            payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+            return payload['staffId']
+        except jwt.ExpiredSignatureError:
+            return None  # Token has expired
+        except jwt.InvalidTokenError:
+            return None  # Invalid token
+
+    @app.get("/")
+    def root():
+        try:
+            return views.all_staff(models.all_staff())
+        except AppException as exc:
+            abort(HTTP_400_BAD_REQUEST, f"Error serving all staff: {exc}")
+
+    @app.post("/login")
+    def login_handler():
+        """Accept password and go back home."""
+        username = request.form["username"]
+        password = request.form["password"]
+        response = make_response(redirect(url_for("root")))
+
+        if (not username) or (not password):
+            response.set_cookie(COOKIE_NAME, "", expires=0)
+            return response
+
+        password = encrypt_password(secret, password)
+        staff_id = models.authenticate(username, password)
+        if staff_id is None:
+            response.set_cookie(COOKIE_NAME, "", expires=0)
+            return response
+
+        token = create_token(staff_id)
+        response.set_cookie(COOKIE_NAME, token, samesite='Lax')
+        return response
+
+    @app.get("/exp/<staff_id>")
+    def exp(staff_id):
+        staff_id = int(staff_id)
+        token = request.cookies.get(COOKIE_NAME)
+        if not token:
+            return jsonify({"error": "Not authenticated"}), 401
+
+        decoded_staff_id = decode_token(token)
+        if decoded_staff_id is None:
+            return jsonify({"error": "Invalid or expired token"}), 401
+
+        try:
+            if int(decoded_staff_id) == staff_id:
+                return views.experiments(models.experiments(staff_id), staff_id)
+            else:
+                return jsonify({"error": "Not authorized"}), 403
+        except AppException as exc:
+            abort(HTTP_400_BAD_REQUEST, f"Error serving experiments for {staff_id}: {exc}")
+
+    @app.get("/heartbeat")
+    def heartbeat():
+        try:
+            return views.heartbeat(HEARTBEAT)
+        except AppException as exc:
+            abort(HTTP_400_BAD_REQUEST, f"Error serving heartbeat: {exc}")
+
+    return app

--- a/docs/21_sessions/templates/staff.html
+++ b/docs/21_sessions/templates/staff.html
@@ -7,6 +7,7 @@
     <script src="/static/htmx.js"></script>
     <script src="/static/alpine.js" defer></script>
     <script src="/static/cookies.js"></script>
+
   </head>
   <body>
     <h1>Staff and Experiments</h1>
@@ -49,6 +50,20 @@
         </fieldset>
       </form>
     </div>
-    <div id="experiments"></div>
+    <div id="experiments"
+         hx-target="this"
+         hx-swap="innerHTML"
+    >
+    </div>
+
+    <script>
+      document.body.addEventListener('htmx:responseError', function(evt) {
+        if (evt.detail.xhr.status === 403) {
+          evt.detail.target.innerHTML = '<p class="error-message">Not authorized</p>';
+        } else if (evt.detail.xhr.status === 401) {
+          evt.detail.target.innerHTML = '<p class="error-message">Not authenticated</p>';
+        }
+      });
+    </script>
   </body>
 </html>

--- a/docs/static/page.css
+++ b/docs/static/page.css
@@ -155,6 +155,11 @@ ul li {
     margin-left: var(--width-li-adjust);
 }
 
+.error-message {
+        color: red;
+        font-weight: bold;
+}
+
 /* Dark mode disabled for now */
 /*
 @media (prefers-color-scheme: dark) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "mccole",
     "polars",
     "prettytable",
+    "pyjwt",
     "pypika",
     "pytest",
     "python-multipart",

--- a/static/page.css
+++ b/static/page.css
@@ -155,6 +155,11 @@ ul li {
     margin-left: var(--width-li-adjust);
 }
 
+.error-message {
+        color: red;
+        font-weight: bold;
+}
+
 /* Dark mode disabled for now */
 /*
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
In this version, once logged in, the app shows the JWT token:
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/f244cfb3-64f0-4082-b106-ceebe9123ff5">
so that we can check its values using jwt.io
<img width="1028" alt="image" src="https://github.com/user-attachments/assets/cf66a05a-23d2-4473-80f4-925c01a3d919">

I'm not sure how to manage the "Not authenticated" (401) and "Not authorized" (403) messages in staff.html. I don't like my solution (adding an event listener... I suppose that htmx can do it in a more elegant way).
I've also added a new style for 401 and 403 error messages.